### PR TITLE
Fix - Bot crashes when user calls bot and is not in a voice channel

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ client.once('ready', () => {
 });
 
 client.on('message', message => {
- if (!message.content.startsWith(prefix) || message.author.bot) return;
+ if (!message.member.voice.channel || !message.content.startsWith(prefix) || message.author.bot) return;
 
  const args = message.content.slice(prefix.length).trim().split(/ +/);
  const command = args.shift().toLowerCase();


### PR DESCRIPTION
Check if user is in a voice channel before trying to connect.